### PR TITLE
Fixes for dropdown and checkboxes fields

### DIFF
--- a/wagtail_advanced_form_builder/forms/advanced_form_builder.py
+++ b/wagtail_advanced_form_builder/forms/advanced_form_builder.py
@@ -35,7 +35,7 @@ class AdvancedFormBuilder(FormBuilder):
 
     def create_dropdown_field(self, field, options):
         options['choices'] = list(map(
-            lambda x: (x.strip(), x.strip()),
+            lambda x: (x.get('value', '').strip(), x.get('value', '').strip()),
             field.choices
         ))
         if field.empty_label:
@@ -45,11 +45,12 @@ class AdvancedFormBuilder(FormBuilder):
 
     def create_checkboxes_field(self, field, options):
         options['choices'] = list(map(
-            lambda x: (x.strip(), x.strip()),
+            lambda x: (x.get('value', '').strip(), x.get('value', '').strip()),
             field.choices
         ))
+
         options['initial'] = list(map(
-            lambda x: (x.strip(), x.strip()),
+            lambda x: x.get('value', '').strip(),
             field.default_value
         ))
 


### PR DESCRIPTION
The `create_dropdown_field` and `create_checkboxes_field` methods in the `AdvancedFormBuilder` class were getting dicts instead of strings as the option choices, and so would fail when attempting to call `strip()` on the dict. 